### PR TITLE
Remove package-lock.json from .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ Thumbs.db
 sftp-config.json
 *.sublime-project
 *.sublime-workspace
-package-lock.json


### PR DESCRIPTION
Remove package-lock.json from .gitignore file because package-lock.json should be pushed to git.