### PR TITLE
Add wp_body_open support to inject script in beginning of body tag

### DIFF
--- a/header.php
+++ b/header.php
@@ -19,7 +19,13 @@
 
 <body <?php body_class(); ?>>
 
-<?php wp_body_open(); ?>
+<?php
+if ( function_exists( 'wp_body_open' ) ) {
+	wp_body_open();
+} else {
+	do_action( 'wp_body_open' );
+}
+?>
 
 <div id="page" class="hfeed site">
 

--- a/header.php
+++ b/header.php
@@ -19,6 +19,16 @@
 
 <body <?php body_class(); ?>>
 
+<?php
+if ( ! function_exists( 'wp_body_open' ) ) {
+	function wp_body_open() {
+		do_action( 'wp_body_open' );
+	}
+} else {
+	wp_body_open();
+}
+?>
+
 <div id="page" class="hfeed site">
 
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'blank-theme' ); ?></a>

--- a/header.php
+++ b/header.php
@@ -19,15 +19,7 @@
 
 <body <?php body_class(); ?>>
 
-<?php
-if ( ! function_exists( 'wp_body_open' ) ) {
-	function wp_body_open() {
-		do_action( 'wp_body_open' );
-	}
-} else {
-	wp_body_open();
-}
-?>
+<?php wp_body_open(); ?>
 
 <div id="page" class="hfeed site">
 

--- a/inc/helpers/template-tags.php
+++ b/inc/helpers/template-tags.php
@@ -190,3 +190,14 @@ function blank_theme_copyright_text() {
 
 	echo $default; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
+
+if ( ! function_exists( 'wp_body_open' ) ) :
+	/**
+	 * Support for sites older than 5.2.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/12563
+	 */
+	function wp_body_open() {
+		do_action( 'wp_body_open' );
+	}
+endif;

--- a/inc/helpers/template-tags.php
+++ b/inc/helpers/template-tags.php
@@ -190,14 +190,3 @@ function blank_theme_copyright_text() {
 
 	echo $default; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
-
-if ( ! function_exists( 'wp_body_open' ) ) :
-	/**
-	 * Support for sites older than 5.2.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/12563
-	 */
-	function wp_body_open() {
-		do_action( 'wp_body_open' );
-	}
-endif;


### PR DESCRIPTION
Add wp_body_open function in header.php. and Also add backward compatibility for wp_body_open function as it was introduced in WordPress 5.2. 

Issue Reference: #60 