### PR TITLE
 fix: theme initialization issue on Windows using Powershell/Command prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"prod": "NODE_ENV=production webpack --progress && npm run pot",
 		"dev": "webpack --watch --progress",
 		"clean": "rm -rf assets/build/*",
-		"init": "./bin/init.js && npm run pot",
+		"init": "node ./bin/init.js && npm run pot",
 		"lint:css": "stylelint assets/src/sass/**/*.scss --syntax scss",
 		"lint:js": "eslint assets/src/js/",
 		"lint:php": "./vendor/bin/phpcs",


### PR DESCRIPTION
## Description
This PR fixes  theme initialization issue on Windows using Powershell/Command prompt while running `npm run init` command. Explicitly uses node to run the `./bin/init.js` tool.
<!-- Very brief idea on what this PR does? No technical details. -->


## How to Test?
1. On Windows platform using either Powershell or Command prompt.
2. Run `git checkout master` to checkout to master branch.
3. Run `npm install` to run JS dependencies.
4. Run `npm run init` to initialize theme, but the command should throw error as in the screenshot.
5. Run `git checkout fix/66` to switch branch.
6. Run `npm run init` to initialize theme, now the command should work properly as intended.
## Screenshots

<!-- Add screenshots or screen recordings if applicable and required. -->

### Before:
![2023-12-12_12-29](https://github.com/rtCamp/blank-theme/assets/8264719/44740373-4afd-4928-9873-edd020592bec)

### After:
![2023-12-12_12-26](https://github.com/rtCamp/blank-theme/assets/8264719/1189b74a-2db1-4bc8-8741-3b529713127c)


## To-do

<!-- Mention anything that needs to be done after this PR as a follow-up or if anything is left uncovered. -->

## Fixes/Covers issue

<!-- Add the issue number which the PR is intended to be for. -->
Fixes #66 

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
